### PR TITLE
feat: Add Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you create [Processor](https://github.com/textlint/textlint/blob/master/docs/
 
 ### `Syntax: Object`
 
-`Syntax` is constants value of Node type.
+`Syntax` is constants value of TxtNode type.
 
 ```js
 import {Syntax} from "textlint-ast-test";

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ If you create [Processor](https://github.com/textlint/textlint/blob/master/docs/
 
 ## Usage
 
+
+### `Syntax: Object`
+
+`Syntax` is constants value of Node type.
+
+```js
+import {Syntax} from "textlint-ast-test";
+Syntax.Str; // "Str"
+```
+
+It is the same values of `ruleContext.Syntax` of textlint's rule.
+
+- [textlint/txtnode.md at master · textlint/textlint](https://github.com/textlint/textlint/blob/master/docs/txtnode.md#type "textlint/txtnode.md at master · textlint/textlint")
+
 ### `test(textlintAST): void`
 
 if the AST is invalid, then throw Error
@@ -30,6 +44,7 @@ test(AST);// if the AST is invalid, then throw Error
 
 isTxtAST(AST);// true or false
 ```
+
 ## Tests
 
     npm test

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "babel src --out-dir lib --source-maps",
+    "build": "NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build",
     "test": "mocha"

--- a/src/TxtNodeSyntax.js
+++ b/src/TxtNodeSyntax.js
@@ -1,0 +1,29 @@
+// LICENSE : MIT
+"use strict";
+/**
+ * Node types list on TxtNode.
+ * @see https://github.com/textlint/textlint/blob/master/docs/txtnode.md
+ * @typedef {{Document: string, Paragraph: string, BlockQuote: string, ListItem: string, List: string, Header: string, CodeBlock: string, HtmlBlock: string, ReferenceDef: string, HorizontalRule: string, Str: string, Break: string, Emphasis: string, Strong: string, Html: string, Link: string, Image: string, Code: string}} TxtNodeSyntax
+ */
+const TxtNodeSyntax = {
+    "Document": "Document",
+    "Paragraph": "Paragraph",
+    "BlockQuote": "BlockQuote",
+    "ListItem": "ListItem",
+    "List": "List",
+    "Header": "Header",
+    "CodeBlock": "CodeBlock",
+    "HtmlBlock": "HtmlBlock",
+    "ReferenceDef": "ReferenceDef",
+    "HorizontalRule": "HorizontalRule",
+    // inline
+    "Str": "Str",
+    "Break": "Break", // well-known Hard Break
+    "Emphasis": "Emphasis",
+    "Strong": "Strong",
+    "Html": "Html",
+    "Link": "Link",
+    "Image": "Image",
+    "Code": "Code"
+};
+export default TxtNodeSyntax;

--- a/src/textlint-ast-test.js
+++ b/src/textlint-ast-test.js
@@ -1,7 +1,9 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
+import Syntax from "./TxtNodeSyntax";
 import {test as UnistTest} from "./unist-test";
+export {Syntax};
 export function isTxtAST(node) {
     try {
         test(node);

--- a/test/TxtNodeSyntax-test.js
+++ b/test/TxtNodeSyntax-test.js
@@ -1,0 +1,12 @@
+// LICENSE : MIT
+"use strict";
+const assert = require("power-assert");
+import TxtNodeSyntax from "../src/TxtNodeSyntax";
+describe("TxtNodeSyntax-test", function () {
+    it("should has types", function () {
+        var typeOfNode = Object.keys(TxtNodeSyntax);
+        assert(typeOfNode != null);
+        assert(typeOfNode.length > 0);
+        typeOfNode.forEach(key => assert(typeof key === "string"));
+    });
+});


### PR DESCRIPTION
Add `Syntax` values that is the same of https://github.com/textlint/textlint/blob/6.4.0/src/shared/type/NodeType.js.

We want to split constants value from textlint's core.

A rule depended on textlint's core and textlint use the use.
It cause a circular reference.
